### PR TITLE
0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## [0.0.3]
+* **Updated Documentation**: Removed outdated HTTPS limitation notices
+
 ## [0.0.2]
 
 ### Features
 * **Pass-through functionality**: Added `HttpHookResponse.passThrough()` for conditional real HTTP requests
-* **Wildcard host matching**: `onTemplate` and `onRegex` without `defaultUrl` parameter match any host  
+* **Wildcard host matching**: `onTemplate` and `onRegex` without `defaultUrl` parameter match any host
 
 ### Breaking Changes
 * `defaultUrl` parameter in `onTemplate`/`onRegex` is now optional with default empty string for wildcard support

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  http_hook: ^0.0.2
+  http_hook: ^0.0.3
 ```
 
 ## 💡 Use Cases

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A lightweight and flexible Dart HTTP request interception and mocking library for testing and debugging. Supports precise URL matching, path template matching, regex matching, and dynamic response generation.
 
-> **⚠️ Important Notice**: The current version only supports HTTP protocol. HTTPS is not supported yet.
+
 
 ## ✨ Features
 
@@ -112,7 +112,7 @@ Use regex for complex URL patterns:
 ```dart
 // Match specific host
 HttpHook.onRegex(
-  defaultUrl:'http://api.example.com',
+  defaultUrl: 'http://api.example.com',
   regex: RegExp(r'^/search/(.+)$'),
   method: HttpHookMethod.get,
   respond: (req, match) {
@@ -342,7 +342,6 @@ test('simple API call', () async {
 
 ## ⚠️ Known Limitations
 
-- **HTTPS Not Supported**: The current version only supports HTTP protocol. HTTPS interception is not available.
 - **Request Body Access**: The `HttpHookRequest` object does not include request body data.
 
 ## 📖 API Reference
@@ -399,7 +398,7 @@ HttpHook.offTemplate(
 
 // Remove regex hook for specific host
 HttpHook.offRegex(
-  'http://api.example.com',
+  defaultUrl: 'http://api.example.com',
   regex: RegExp(r'^/search/(.+)$'),
 );
 
@@ -418,12 +417,12 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  http_hook: ^0.0.1
+  http_hook: ^0.0.2
 ```
 
 ## 💡 Use Cases
 
-- **Unit & Integration Testing**: Mock external APIs without running servers (HTTP only)
+- **Unit & Integration Testing**: Mock external APIs without running servers (HTTP & HTTPS)
 - **Development & Debugging**: Test different API responses and error conditions
 - **Network Simulation**: Simulate slow connections, timeouts, and failures
 - **API Prototyping**: Create mock responses before backend implementation

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -4,7 +4,6 @@
 
 一个轻量、灵活的 Dart HTTP 请求拦截与模拟库，适用于测试和调试。支持精准 URL 匹配、路径模板匹配、正则匹配和动态响应生成。
 
-> **⚠️ 重要提示**: 当前版本仅支持 HTTP 协议，暂不支持 HTTPS。
 
 ## ✨ 特性
 
@@ -343,7 +342,6 @@ test('简单 API 调用', () async {
 
 ## ⚠️ 已知限制
 
-- **不支持 HTTPS**: 当前版本仅支持 HTTP 协议，不支持 HTTPS 拦截。
 - **请求体访问限制**: `HttpHookRequest` 对象不包含请求体数据。
 
 ## 📖 API 参考
@@ -389,7 +387,7 @@ HttpHook.off('http://api.example.com/user/1');
 
 // 移除特定主机的模板 hook
 HttpHook.offTemplate(
-  'http://api.example.com',
+  defaultUrl: 'http://api.example.com',
   template: '/user/:id',
 );
 
@@ -400,7 +398,7 @@ HttpHook.offTemplate(
 
 // 移除特定主机的正则 hook
 HttpHook.offRegex(
-  'http://api.example.com',
+  defaultUrl: 'http://api.example.com',
   regex: RegExp(r'^/search/(.+)$'),
 );
 
@@ -419,12 +417,12 @@ HttpHook.destroy();
 
 ```yaml
 dev_dependencies:
-  http_hook: ^0.0.1
+  http_hook: ^0.0.2
 ```
 
 ## 💡 使用场景
 
-- **单元测试和集成测试**: 无需运行服务器即可模拟外部 API（仅限 HTTP）
+- **单元测试和集成测试**: 无需运行服务器即可模拟外部 API（HTTP 和 HTTPS）
 - **开发和调试**: 测试不同的 API 响应和错误条件
 - **网络模拟**: 模拟慢连接、超时和失败
 - **API 原型设计**: 在后端实现之前创建模拟响应

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -417,7 +417,7 @@ HttpHook.destroy();
 
 ```yaml
 dev_dependencies:
-  http_hook: ^0.0.2
+  http_hook: ^0.0.3
 ```
 
 ## 💡 使用场景

--- a/lib/src/http_hook.dart
+++ b/lib/src/http_hook.dart
@@ -112,7 +112,8 @@ class HttpHook {
   /// [defaultUrl] can be specified to restrict matches to a specific host.
   /// If is empty, matches any host with the given template.
   ///
-  /// [method] optionally restricts by HTTP method.
+  /// [method], only requests with the matching HTTP method
+  /// will be intercepted.
   ///
   /// [respond] handles matching requests.）
   static void onTemplate({
@@ -147,7 +148,8 @@ class HttpHook {
   /// [defaultUrl] can be specified to restrict matches to a specific host.
   /// If is empty, matches any host with the given regex pattern.
   ///
-  /// [method] optionally restricts by HTTP method.
+  /// [method], only requests with the matching HTTP method
+  /// will be intercepted.
   ///
   /// [respond] handles matching requests.
   static void onRegex({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_hook
 description: Lightweight Dart HTTP request interception and mocking library. Supports URL matching, templates, regex, wildcards, and pass-through.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/drown0315/http_hook
 issue_tracker: https://github.com/drown0315/http_hook/issues
 

--- a/test/http_test.dart
+++ b/test/http_test.dart
@@ -232,15 +232,15 @@ void main() {
       expect(wildcardData['type'], 'wildcard');
 
       /// Act & Assert - Host-specific rule should work for specific host
-      final specificResponse = await http
-          .get(Uri.parse('http://microsoft.com/specific-only/456'));
+      final specificResponse =
+          await http.get(Uri.parse('http://microsoft.com/specific-only/456'));
       final specificData = jsonDecode(specificResponse.body);
       expect(specificData['type'], 'specific');
 
       /// Act & Assert - Non-matching host for specific rule should fail (network error expected)
       try {
-        final nonMatchResponse = await http
-            .get(Uri.parse('http://amazon.com/specific-only/789'));
+        final nonMatchResponse =
+            await http.get(Uri.parse('http://amazon.com/specific-only/789'));
         // If we get here, it means the request went through without interception
         expect(nonMatchResponse.statusCode, isNot(200));
       } catch (e) {


### PR DESCRIPTION
## 📄 v0.0.3 Documentation Update: Remove Outdated HTTPS Limitation

### ✨ What’s Changed

- **Removed all references to "HTTPS not supported"** in both English and Chinese documentation.
- Updated all protocol-related descriptions to reflect that **HttpHook now fully supports both HTTP and HTTPS**.
- Adjusted use case and limitation sections to accurately describe protocol support.
- Updated version numbers in documentation to `^0.0.3` for consistency.

### 📝 Why

- Previous documentation incorrectly stated that HTTPS was not supported.
- Actual implementation and tests confirm that HTTPS interception and mocking work as expected.
- This update ensures new users are not misled and can confidently use HttpHook for both HTTP and HTTPS scenarios.

**No Breaking Change.**