### PR TITLE
feat: add common HTTP status response factories and remove redundant …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Changelog
 
+## [0.0.4]
+
+### Features
+* **Flexible Response Body Types**: Support for String, List<int>, and Stream<List<int>>
+* **Binary Response Support**: Added `HttpHookResponse.binary()` factory for binary data
+* **Streaming Response Support**: Added `HttpHookResponse.stream()` factory for streaming data
+* **Common HTTP Status Responses**: Added convenient factories for common HTTP status codes
+  - `HttpHookResponse.notFound()` - 404 Not Found
+  - `HttpHookResponse.internalServerError()` - 500 Internal Server Error
+  - `HttpHookResponse.badRequest()` - 400 Bad Request
+  - `HttpHookResponse.unauthorized()` - 401 Unauthorized
+  - `HttpHookResponse.forbidden()` - 403 Forbidden
+
+### Improvements
+* **Enhanced Response Flexibility**: HttpHookResponse.body now accepts String, List<int>, and Stream<List<int>>
+* **Better Binary Data Handling**: Native support for binary responses without string conversion
+* **Streaming Capabilities**: Direct support for streaming responses for large data scenarios
+* **Simplified Async Handling**: Async operations are handled in the response handler, not in the response body
+* **Removed Redundant API**: Removed `HttpHookResponse.error()` as it was functionally equivalent to the constructor
+
+### Documentation
+* **Added Examples**: New examples for binary, streaming, and async responses
+
 ## [0.0.3]
+
+### Documentation
 * **Updated Documentation**: Removed outdated HTTPS limitation notices
 
 ## [0.0.2]

--- a/README.md
+++ b/README.md
@@ -187,10 +187,65 @@ HttpHookResponse.json({'key': 'value'})
 HttpHookResponse.ok('Plain text response')
 ```
 
+### Binary Responses
+
+```dart
+// Binary data
+HttpHookResponse.binary(
+  [0x89, 0x50, 0x4E, 0x47], // PNG header
+  contentType: 'image/png',
+);
+
+// Or use the general constructor
+HttpHookResponse(
+  statusCode: 200,
+  body: [0x48, 0x65, 0x6C, 0x6C, 0x6F], // "Hello" in bytes
+  headers: {'content-type': 'application/octet-stream'},
+);
+```
+
+### Streaming Responses
+
+```dart
+// Stream data chunks
+HttpHookResponse.stream(
+  Stream.fromIterable([
+    utf8.encode('Hello'),
+    utf8.encode(' '),
+    utf8.encode('World'),
+  ]),
+  contentType: 'text/plain',
+);
+```
+
+### Async Handler Responses
+
+```dart
+// Async handler with string response
+HttpHook.on(
+  'http://api.example.com/async',
+  method: HttpHookMethod.get,
+  respond: (req, match) async {
+    final data = await someAsyncOperation();
+    return HttpHookResponse.ok(data);
+  },
+);
+
+// Async handler with stream response
+HttpHook.on(
+  'http://api.example.com/stream',
+  method: HttpHookMethod.get,
+  respond: (req, match) async {
+    final stream = await getDataStream();
+    return HttpHookResponse.stream(stream);
+  },
+);
+```
+
 ### Error Responses
 
 ```dart
-HttpHookResponse.error(404, body: 'Not Found')
+HttpHookResponse(statusCode: 404, body: 'Not Found')
 ```
 
 ### Custom Responses
@@ -377,6 +432,28 @@ class MatchResult {
   final Map<String, String>? params;     // Template parameters
   final RegExpMatch? regexMatch;         // Regex match groups
 }
+```
+
+### HttpHookResponse
+
+Response factory methods for creating mock responses:
+
+```dart
+// Success responses
+HttpHookResponse.ok('Success!')                    // 200 OK
+HttpHookResponse.json({'key': 'value'})            // 200 OK with JSON
+HttpHookResponse.binary([0x48, 0x65, 0x6C, 0x6C]) // 200 OK with binary data
+HttpHookResponse.stream(stream)                     // 200 OK with streaming data
+
+// Error responses
+HttpHookResponse.notFound('Resource not found')           // 404 Not Found
+HttpHookResponse.internalServerError('Server error')      // 500 Internal Server Error
+HttpHookResponse.badRequest('Invalid parameters')         // 400 Bad Request
+HttpHookResponse.unauthorized('Invalid credentials')      // 401 Unauthorized
+HttpHookResponse.forbidden('Access denied')              // 403 Forbidden
+
+// Pass-through (let real request proceed)
+HttpHookResponse.passThrough()
 ```
 
 ### Removing Hooks

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -190,7 +190,7 @@ HttpHookResponse.ok('纯文本响应')
 ### 错误响应
 
 ```dart
-HttpHookResponse.error(404, body: '未找到')
+HttpHookResponse(statusCode: 404, body: '未找到')
 ```
 
 ### 自定义响应

--- a/test/response_types_test.dart
+++ b/test/response_types_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:async';
+import 'package:http/http.dart' as http;
+import 'package:http_hook/http_hook.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpHookResponse Body Types', () {
+    setUp(() => HttpHook.start());
+    tearDown(() => HttpHook.destroy());
+
+    test('String body', () async {
+      /// Arrange.
+      HttpHook.on(
+        'http://example.com/string',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.ok('Hello World'),
+      );
+
+      /// Act.
+      final response = await http.get(Uri.parse('http://example.com/string'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.body, 'Hello World');
+    });
+
+    test('Binary body (List<int>)', () async {
+      /// Arrange.
+      final pngHeader = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+      HttpHook.on(
+        'http://example.com/image',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.binary(
+          pngHeader,
+          contentType: 'image/png',
+        ),
+      );
+
+      /// Act.
+      final response = await http.get(Uri.parse('http://example.com/image'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.headers['content-type'], 'image/png');
+      expect(response.bodyBytes, pngHeader);
+    });
+
+    test('Stream body', () async {
+      /// Arrange.
+      final stream = Stream.fromIterable([
+        utf8.encode('Hello'),
+        utf8.encode(' '),
+        utf8.encode('World'),
+      ]);
+      HttpHook.on(
+        'http://example.com/stream',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.stream(
+          stream,
+          contentType: 'text/plain',
+        ),
+      );
+
+      /// Act.
+      final response = await http.get(Uri.parse('http://example.com/stream'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.headers['content-type'], 'text/plain');
+      expect(response.body, 'Hello World');
+    });
+
+    test('Async handler with Stream response', () async {
+      /// Arrange.
+      HttpHook.on(
+        'http://example.com/async-handler',
+        method: HttpHookMethod.get,
+        respond: (req, match) async {
+          return HttpHookResponse.stream(
+            Stream.fromIterable([
+              utf8.encode('Async'),
+              utf8.encode(' '),
+              utf8.encode('Handler'),
+            ]),
+            contentType: 'text/plain',
+          );
+        },
+      );
+
+      /// Act.
+      final response =
+          await http.get(Uri.parse('http://example.com/async-handler'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.body, 'Async Handler');
+    });
+
+    test('JSON response with binary data', () async {
+      /// Arrange.
+      final jsonData = {
+        'message': 'Hello',
+        'bytes': [1, 2, 3, 4]
+      };
+      HttpHook.on(
+        'http://example.com/json-binary',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.json(jsonData),
+      );
+
+      /// Act.
+      final response =
+          await http.get(Uri.parse('http://example.com/json-binary'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(
+          response.headers['content-type'], 'application/json; charset=utf-8');
+      final data = jsonDecode(response.body);
+      expect(data['message'], 'Hello');
+      expect(data['bytes'], [1, 2, 3, 4]);
+    });
+
+    test('Error response with binary body', () async {
+      /// Arrange.
+      final errorBytes = utf8.encode('Binary Error Message');
+      HttpHook.on(
+        'http://example.com/error-binary',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.internalServerError(
+          String.fromCharCodes(errorBytes),
+        ),
+      );
+
+      /// Act.
+      final response =
+          await http.get(Uri.parse('http://example.com/error-binary'));
+
+      /// Assert.
+      expect(response.statusCode, 500);
+      expect(response.body, 'Binary Error Message');
+    });
+
+    test('Empty body handling', () async {
+      /// Arrange.
+      HttpHook.on(
+        'http://example.com/empty',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.ok(''),
+      );
+
+      /// Act.
+      final response = await http.get(Uri.parse('http://example.com/empty'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.body, '');
+    });
+
+    test('Large binary data', () async {
+      /// Arrange.
+      final largeData = List.generate(10000, (i) => i % 256);
+      HttpHook.on(
+        'http://example.com/large-binary',
+        method: HttpHookMethod.get,
+        respond: (req, match) => HttpHookResponse.binary(
+          largeData,
+          contentType: 'application/octet-stream',
+        ),
+      );
+
+      /// Act.
+      final response =
+          await http.get(Uri.parse('http://example.com/large-binary'));
+
+      /// Assert.
+      expect(response.statusCode, 200);
+      expect(response.bodyBytes.length, 10000);
+      expect(response.bodyBytes.first, 0);
+      expect(response.bodyBytes.last, 15); // 9999 % 256 = 15
+    });
+  });
+}


### PR DESCRIPTION
## 🎯 Overview

This release adds convenient factory methods for common HTTP status codes and simplifies the API design by removing redundant functionality.

## ✨ New Features

### Common HTTP Status Response Factories

Added convenient factories for the most commonly used HTTP status codes:

```dart
// Error responses
HttpHookResponse.notFound('Resource not found')           // 404 Not Found
HttpHookResponse.internalServerError('Server error')      // 500 Internal Server Error
HttpHookResponse.badRequest('Invalid parameters')         // 400 Bad Request
HttpHookResponse.unauthorized('Invalid credentials')      // 401 Unauthorized
HttpHookResponse.forbidden('Access denied')              // 403 Forbidden
```

These factories provide:
- **Semantic method names** - No need to remember status code numbers
- **Reasonable defaults** - Appropriate default messages and reason phrases
- **Consistent API** - Follows the same pattern as other response factories

## 🔧 Improvements

### Simplified Async Handling

- **Removed Future wrapper** from response body types (`Future<String>`, `Future<List<int>>`, etc.)
- **Async operations** are now handled in the response handler, not in the response body
- **Cleaner design** - Handler is already async, no need for additional Future layers

### API Cleanup

- **Removed `HttpHookResponse.error()`** - Functionally equivalent to the constructor
- **Reduced complexity** - Fewer APIs to learn and maintain
- **Better consistency** - All response factories follow the same pattern

## 🧪 Testing

- Added comprehensive test coverage for all new response factories
- Updated existing tests to use new APIs
- Added new example demonstrating common HTTP responses

## 📚 Documentation

- Updated API Reference with new response factories
- Added examples showing conditional response patterns
- Updated CHANGELOG with detailed feature descriptions
- Created new example file: `example/common_responses_demo.dart`

## Breaking Changes

- **`HttpHookResponse.error()`** has been removed - use `HttpHookResponse(statusCode: 404, body: 'message')` instead
- **Future response body types** are no longer supported - handle async operations in the response handler

## 🎉 Usage Examples

```dart
// Conditional responses with new factories
HttpHook.on(
  'http://api.example.com/user/:id',
  method: HttpHookMethod.get,
  respond: (req, match) {
    final userId = match.params!['id'];
    
    if (userId == '123') {
      return HttpHookResponse.json({'id': '123', 'name': 'Alice'});
    } else if (userId == '999') {
      return HttpHookResponse.notFound('User not found');  // Clean!
    } else {
      return HttpHookResponse.internalServerError('Database error');  // Semantic!
    }
  },
);

// Async handler with streaming response
HttpHook.on(
  'http://api.example.com/stream',
  method: HttpHookMethod.get,
  respond: (req, match) async {
    final stream = await getDataStream();
    return HttpHookResponse.stream(stream);  // Direct, no Future wrapper
  },
);
```


---

**Version**: 0.0.4  
**Type**: Feature + Breaking Change  
